### PR TITLE
Update to support Dnd 3 0 0

### DIFF
--- a/module.json
+++ b/module.json
@@ -178,7 +178,7 @@
 				"compatibility": {
 					"minimum": "2.0.1",
 					"verified": "2.0.1",
-					"maximum": "3"
+					"maximum": "3.1.0"
 				}
 			}
 		]

--- a/module.json
+++ b/module.json
@@ -170,6 +170,50 @@
 			"system": "dnd5e"
 		}
 	],
+	"packFolders": [
+		{
+			"name": "HnD",
+			"sorting": "m",
+			"color": "#3C8633",
+			"packs": [
+			],
+			"folders": [
+				{
+					"name": "Personnages",
+					"sorting": "m",
+					"color": "#377C2E",
+					"packs": [
+						"HnD-dons",
+						"HnD-capacites-de-classes",
+						"HnD-grimoire",
+						"HnD-races",
+						"HnD-traits-raciaux",
+						"HnD-équipement-aventurier",
+						"HnD-historiques",
+						"HnD-Classes-spécialisations",
+						"HnD-aptitudes-historiques"
+					]
+				},
+				{
+					"name": "Regles",
+					"sorting": "m",
+					"color": "#306C29",
+					"packs": [
+						"HnD-tables-de-tresors",
+						"HnD-conditions",
+						"HnD-bestaire",
+						"HnD-capacités-du-bestiaire",
+						"HnD-objets-magiques-et-trésors",
+						"HnD-tables-de-rencontres-aleatoires",
+						"HnD-tables-d'evenements-aleatoires",
+						"HnD-poisons-et-maladies",
+						"HnD-folies",
+						"HnD-pieges"
+					]
+				}
+			]
+		}
+	],
 	"relationships": {
 		"systems": [
 			{


### PR DESCRIPTION
The first commit is to make sure HnD will not be disabled by an upgrade to DnD3.0.0, which confuses users for no reason. The minimum set to 3.1.0 is become I expect DnD3.0.0 to have minor patches (3.0.1, 3.0.2, etc.) to fix minor bugs, and there's no point in repeating the inconvenience for HnD users.

The second commit is a convenience commit: An initial folder structure for HnD compendiums, as the original HnD trick to color the compendiums do not work anymore.